### PR TITLE
[codex] fix mobile home top spacing

### DIFF
--- a/quartz/components/TerminalHome.tsx
+++ b/quartz/components/TerminalHome.tsx
@@ -962,7 +962,7 @@ export default (() => {
   display: none;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 768px) {
   body[data-slug="index"] .page > #quartz-body {
     grid-template-areas:
       "grid-center"

--- a/quartz/components/TerminalHome.tsx
+++ b/quartz/components/TerminalHome.tsx
@@ -962,6 +962,25 @@ export default (() => {
   display: none;
 }
 
+@media (max-width: 800px) {
+  body[data-slug="index"] .page > #quartz-body {
+    grid-template-areas:
+      "grid-center"
+      "grid-sidebar-left"
+      "grid-sidebar-right"
+      "grid-footer";
+  }
+
+  body[data-slug="index"] .page > #quartz-body > .center {
+    grid-area: grid-center;
+  }
+
+  body[data-slug="index"] .page-header > header {
+    display: none;
+    margin: 0;
+  }
+}
+
 `
 
   return TerminalHome


### PR DESCRIPTION
## Summary

- Adjust the homepage mobile grid so the terminal hero renders before the sidebars.
- Hide the empty homepage header on mobile to remove its default spacing.

## Why

On mobile, the homepage terminal window was pushed down by the default mobile sidebar/header layout, leaving a large blank area above the first visible content.

## Impact

The homepage now opens with the terminal window near the top of the mobile viewport while preserving the existing sidebar content below it.

## Validation

- `npx quartz build`
- `npm run check`
- Pre-commit hook: `tsc --noEmit`, staged Prettier check
- Pre-push hook: full `tsc --noEmit`, `npm test`
- Manual mobile viewport check at 393x852: `.terminal-window` top moved from about `193px` to `8px`.
